### PR TITLE
Update CustomPresets.Designer.cs

### DIFF
--- a/AMD APU Tuning Utility/CustomPresets.Designer.cs
+++ b/AMD APU Tuning Utility/CustomPresets.Designer.cs
@@ -1020,6 +1020,11 @@
             this.nudShortBoostTDP.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.nudShortBoostTDP.Location = new System.Drawing.Point(231, 151);
             this.nudShortBoostTDP.Margin = new System.Windows.Forms.Padding(6);
+            this.nudShortBoostTDP.Maximum = new decimal(new int[] {
+            200,
+            0,
+            0,
+            0});
             this.nudShortBoostTDP.Name = "nudShortBoostTDP";
             this.nudShortBoostTDP.Size = new System.Drawing.Size(126, 22);
             this.nudShortBoostTDP.TabIndex = 19;
@@ -1044,7 +1049,7 @@
             this.nudLongTDP.Location = new System.Drawing.Point(231, 104);
             this.nudLongTDP.Margin = new System.Windows.Forms.Padding(6);
             this.nudLongTDP.Maximum = new decimal(new int[] {
-            120,
+            200,
             0,
             0,
             0});
@@ -1058,7 +1063,7 @@
             this.nudTDP.Location = new System.Drawing.Point(231, 80);
             this.nudTDP.Margin = new System.Windows.Forms.Padding(6);
             this.nudTDP.Maximum = new decimal(new int[] {
-            120,
+            200,
             0,
             0,
             0});


### PR DESCRIPTION
This changes are to AMD Advanced laptops, this laptops that has SmartShift combines the CPU and GPU TDP in one single value, then this values pass from 120watts and can reach 190watts in Asus Strix G15 case(Ryzen 9 5900HX 100Watts and RX 6800M 170Watts = 270Watts merged in CPU wattage) or MSI Delta 15 (Ryzen 7 5800H 54W and RX 6700M 135W = 189Watts merged in CPU Wattage), and this values are to the Fast and Slow TDP, I just change the maximum values from 120watts to 200watts, this is to my case of MSI Delta 15, if you want feel free to change to other values